### PR TITLE
[Oztechan/Global#21] Rename Config repo to Global

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -16,4 +16,4 @@ jobs:
         with:
           GH_PAT: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
           PR_LABELS: "config"
-          COMMIT_PREFIX: "[Oztechan/Config#4] Global config update"
+          COMMIT_PREFIX: "[Oztechan/Global#4] Global config update"

--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -1,0 +1,20 @@
+name: Project Automations
+on:
+  issues:
+    types:
+      - opened
+      - reopened
+  pull_request:
+    types:
+      - opened
+      - ready_for_review
+      - reopened
+      - closed
+      - converted_to_draft
+
+jobs:
+  ProjectAutomations:
+    uses: Oztechan/actions/.github/workflows/project.yml@6c5f8bec653f12c288d4bb6f82e3c4f1e0611f25
+    with:
+      project_id: 8
+    secrets: inherit

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -17,7 +17,7 @@ Every commit message should match the following format `[Oztechan/REPO_NAME#ISSU
 Example:
 
 ```
-[Oztechan/Config#123] My cool feature
+[Oztechan/Global#123] My cool feature
 ```
 
 ## Pull Request
@@ -33,7 +33,7 @@ Pull Request title should follow below format:
 Example:
 
 ```
-[Oztechan/Config#123] Whatever the name of ticket is
+[Oztechan/Global#123] Whatever the name of ticket is
 ```
 
 ### Description
@@ -43,7 +43,7 @@ Description has to have `Resloves Oztechan/REPO_NAME#ISSUE_ID` with relevant iss
 Example:
 
 ```
-Resolves Oztechan/Config#123
+Resolves Oztechan/Global#123
 
 Some description.
 ```

--- a/docs/PULL_REQUEST_TEMPLATE.md
+++ b/docs/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@
 Resolves Oztechan/REPO_NAME#ISSUE_ID
 <!--
 Pull Request Checklist
-1. I have read the https://github.com/Oztechan/Config/blob/develop/docs/CONTRIBUTING.md
+1. I have read the https://github.com/Oztechan/Global/blob/develop/docs/CONTRIBUTING.md
 2. PR title in the format of `[Oztechan/REPO_NAME#ISSUE_ID] ISSUE_TITLE`
 3. I have added a valid description and 
 4. I replaced `REPO_NAME` with the name of repository.

--- a/renovate.json
+++ b/renovate.json
@@ -9,14 +9,14 @@
   "rebaseWhen": "conflicted",
   "gitAuthor": "Renovate <renovate@oztechan.com>",
   "commitBody": "Co-authored-by: Mustafa Ozhan <mr.mustafa.ozhan@gmail.com>",
-  "commitMessageAction": "[Oztechan/Config#12] Update",
+  "commitMessageAction": "[Oztechan/Global#12] Update",
   "git-submodules": {
     "enabled": true,
     "groupName": "Git Submodules"
   },
   "lockFileMaintenance": {
     "enabled": true,
-    "commitMessageAction": "[Oztechan/Config#12] Lock file maintenance"
+    "commitMessageAction": "[Oztechan/Global#12] Lock file maintenance"
   },
   "packageRules": [
     {


### PR DESCRIPTION
## Description

Resolves Oztechan/Global#21
<!--
Pull Request Checklist
1. I have read the https://github.com/Oztechan/Global/blob/develop/docs/CONTRIBUTING.md
2. PR title in the format of `[Oztechan/REPO_NAME#ISSUE_ID] ISSUE_TITLE`
3. I have added a valid description and 
4. I replaced `REPO_NAME` with the name of repository.
5. I replaced `ISSUE_ID` with the ID(number in the link) of issue.
4. I have tested the app before creating this PR 
-->
