### PR TITLE
[Oztechan/Global#23] Use File Sync templates for the repo names

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -1,9 +1,8 @@
 group:
   # Docs
   - files:
-      - source: docs/CONTRIBUTING.md
-      - source: docs/ISSUE_TEMPLATE.md
-      - source: docs/PULL_REQUEST_TEMPLATE.md
+      - source: docs/
+        template: true
     repos: |
       Oztechan/CCC
       Oztechan/Tracefit
@@ -33,3 +32,15 @@ group:
       Oztechan/CCC
       Oztechan/Tracefit
       Oztechan/actions
+
+Oztechan/CCC:
+  - source: docs/
+    template:
+      repository:
+        name: 'CCC'
+
+Oztechan/TraceFit:
+  - source: docs/
+    template:
+      repository:
+        name: 'TraceFit'

--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -44,3 +44,8 @@ Oztechan/TraceFit:
     template:
       repository:
         name: 'TraceFit'
+Oztechan/actions:
+  - source: docs/
+    template:
+      repository:
+        name: 'actions'

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - develop
+  pull_request:
   workflow_dispatch:
 jobs:
   GlobalConfigUpdate:

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - develop
-  pull_request:
   workflow_dispatch:
 jobs:
   GlobalConfigUpdate:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Example:
 
 ## Commit Message
 
-Every commit message should match the following format `[Oztechan/REPO_NAME#ISSUE_ID] Commit message`
+Every commit message should match the following format `[Oztechan/{{ repository.name }}#ISSUE_ID] Commit message`
 
 Example:
 
@@ -27,7 +27,7 @@ Example:
 Pull Request title should follow below format:
 
 ```
-[Oztechan/REPO_NAME#ISSUE_ID] ISSUE_TITLE
+[Oztechan/{{ repository.name }}#ISSUE_ID] ISSUE_TITLE
 ```
 
 Example:

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -38,7 +38,7 @@ Example:
 
 ### Description
 
-Description has to have `Resloves Oztechan/REPO_NAME#ISSUE_ID` with relevant issue. It will help automatically close relevant issue once the PR is merged.
+Description has to have `Resloves Oztechan/{{ repository.name }}#ISSUE_ID` with relevant issue. It will help automatically close relevant issue once the PR is merged.
 
 Example:
 

--- a/docs/PULL_REQUEST_TEMPLATE.md
+++ b/docs/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,11 @@
 ## Description
 
-Resolves Oztechan/REPO_NAME#ISSUE_ID
+Resolves Oztechan/{{ repository.name }}#ISSUE_ID
 <!--
 Pull Request Checklist
 1. I have read the https://github.com/Oztechan/Global/blob/develop/docs/CONTRIBUTING.md
-2. PR title in the format of `[Oztechan/REPO_NAME#ISSUE_ID] ISSUE_TITLE`
+2. PR title in the format of `[Oztechan/{{ repository.name }}#ISSUE_ID] ISSUE_TITLE`
 3. I have added a valid description and 
-4. I replaced `REPO_NAME` with the name of repository.
-5. I replaced `ISSUE_ID` with the ID(number in the link) of issue.
-4. I have tested the app before creating this PR 
+4. I replaced `ISSUE_ID` with the ID(number in the link) of issue.
+5. I have tested the app before creating this PR 
 -->


### PR DESCRIPTION
## Description

Resolves Oztechan/Global#23
<!--
Pull Request Checklist
1. I have read the https://github.com/Oztechan/Global/blob/develop/docs/CONTRIBUTING.md
2. PR title in the format of `[Oztechan/REPO_NAME#ISSUE_ID] ISSUE_TITLE`
3. I have added a valid description and 
4. I replaced `REPO_NAME` with the name of repository.
5. I replaced `ISSUE_ID` with the ID(number in the link) of issue.
4. I have tested the app before creating this PR 
-->
