### PR TITLE
[Oztechan/Global#69] Add workaround for using env variables in reusable workflows

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -13,8 +13,14 @@ on:
       - converted_to_draft
 
 jobs:
+  milestone:
+      runs-on: ubuntu-latest
+      steps: [ run: echo ]
+      outputs:
+        value: ${{ secrets.MILESTONE }}
+
   ProjectAutomations:
     uses: Oztechan/Global/.github/workflows/reusable-project.yml@develop
     with:
       project_id: 8
-    secrets: inherit
+      milestone: ${{ needs.milestone.outputs.value }}

--- a/.github/workflows/reusable-project.yml
+++ b/.github/workflows/reusable-project.yml
@@ -6,9 +6,9 @@ on:
       project_id:
         required: true
         type: string
-
-env:
-  MILESTONE: ${{ secrets.MILESTONE }}
+      milestone:
+        required: true
+        type: string
 
 jobs:
   ProjectAutomations:
@@ -25,7 +25,7 @@ jobs:
           project_id: ${{ inputs.project_id }}
           resource_node_id: ${{ github.event.issue.node_id }}
           operation_mode: custom_field
-          custom_field_values: '[{\"name\": \"Milestone\",\"type\": \"text\",\"value\": \"${{ MILESTONE }}\"}]'
+          custom_field_values: '[{\"name\": \"Milestone\",\"type\": \"text\",\"value\": \"${{ inputs.milestone }}\"}]'
 
       - name: 'Move Related Issue to "🏗 PR Review"'
         if: |
@@ -52,7 +52,7 @@ jobs:
           project_id: ${{ inputs.project_id }}
           resource_node_id: ${{ github.event.pull_request.node_id }}
           operation_mode: custom_field
-          custom_field_values: '[{\"name\": \"Milestone\",\"type\": \"text\",\"value\": \"${{ MILESTONE }}\"}]'
+          custom_field_values: '[{\"name\": \"Milestone\",\"type\": \"text\",\"value\": \"${{ inputs.milestone }}\"}]'
 
       - name: 'Move Related Issue to "🚧 In Progress"'
         if: |


### PR DESCRIPTION
Resolves Oztechan/Global#69
<!--
Pull Request Checklist
1. I have read the https://github.com/{{ repository.owner }}/{{ repository.name }}/blob/develop/docs/CONTRIBUTING.md
2. PR title in the format of `[{{ repository.owner }}/{{ repository.name }}#ISSUE_ID] ISSUE_TITLE`
3. I have added a valid description and 
4. I replaced `ISSUE_ID` with the ID(number in the link) of issue.
5. I have tested the app before creating this PR 
-->
