### PR TITLE
[Oztechan/Global#205] Add .claude to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.claude
+.idea


### PR DESCRIPTION
Add a .gitignore to exclude local-only tool directories from the repo.

- Add `.gitignore` with `.claude` and `.idea` entries

Resolves Oztechan/Global#205