### PR TITLE
[Oztechan/Global#209] Add AdTrack to config file sync

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -51,6 +51,25 @@ Oztechan/TraceFit:
   - source: .github/auto_assign.yml
   - source: .github/CODEOWNERS
 
+Oztechan/AdTrack:
+  - source: relative/renovate.json
+    dest: renovate.json
+    template:
+      repository:
+        name: 'AdTrack'
+        owner: "Oztechan"
+        dependencyIssueId: "41"
+  - source: relative/docs/
+    dest: docs/
+    template:
+      repository:
+        name: 'AdTrack'
+        owner: "Oztechan"
+  - source: codecov.yml
+  - source: detekt.yml
+  - source: .github/auto_assign.yml
+  - source: .github/CODEOWNERS
+
 SubMob/BaseMob:
   - source: relative/renovate.json
     dest: renovate.json


### PR DESCRIPTION
Add `Oztechan/AdTrack` to `.github/sync.yml` so shared config is mirrored to it like the other app repos (CCC, TraceFit).

Synced files:
- templated `renovate.json` — `dependencyIssueId` = Oztechan/AdTrack#41
- `docs/` templates (PR/issue templates, CONTRIBUTING)
- `codecov.yml`, `detekt.yml`
- `.github/auto_assign.yml`, `.github/CODEOWNERS`

Once merged to `develop`, the `Global Config Update` workflow (`BetaHuhn/repo-file-sync-action`) opens a sync PR on AdTrack with these files.

Resolves Oztechan/Global#209