### PR TITLE
[Oztechan/Global#211] Make Renovate iOS SPM manager per-repo + fix dependency name

### DIFF
--- a/.github/sync.yml
+++ b/.github/sync.yml
@@ -6,6 +6,7 @@ Oztechan/Global:
         name: 'Global'
         owner: "Oztechan"
         dependencyIssueId: "12"
+        iosProjectPath: '^$' # no iOS project — never matches
   - source: relative/docs/
     dest: docs/
     template:
@@ -21,6 +22,7 @@ Oztechan/CCC:
         name: 'CCC'
         owner: "Oztechan"
         dependencyIssueId: "1457"
+        iosProjectPath: '^ios/CCC\\.xcodeproj/project\\.pbxproj$'
   - source: relative/docs/
     dest: docs/
     template:
@@ -40,6 +42,7 @@ Oztechan/TraceFit:
         name: 'TraceFit'
         owner: "Oztechan"
         dependencyIssueId: "11"
+        iosProjectPath: '^ios/TraceFit\\.xcodeproj/project\\.pbxproj$'
   - source: relative/docs/
     dest: docs/
     template:
@@ -59,6 +62,7 @@ Oztechan/AdTrack:
         name: 'AdTrack'
         owner: "Oztechan"
         dependencyIssueId: "41"
+        iosProjectPath: '^iosApp/iosApp\\.xcodeproj/project\\.pbxproj$'
   - source: relative/docs/
     dest: docs/
     template:
@@ -78,6 +82,7 @@ SubMob/BaseMob:
         name: 'BaseMob'
         owner: "SubMob"
         dependencyIssueId: "32"
+        iosProjectPath: '^$' # no iOS project — never matches
   - source: relative/docs/
     dest: docs/
     template:
@@ -95,6 +100,7 @@ SubMob/ScopeMob:
         name: 'ScopeMob'
         owner: "SubMob"
         dependencyIssueId: "32"
+        iosProjectPath: '^$' # no iOS project — never matches
   - source: relative/docs/
     dest: docs/
     template:
@@ -112,6 +118,7 @@ SubMob/LogMob:
         name: 'LogMob'
         owner: "SubMob"
         dependencyIssueId: "27"
+        iosProjectPath: '^$' # no iOS project — never matches
   - source: relative/docs/
     dest: docs/
     template:
@@ -129,6 +136,7 @@ SubMob/ParserMob:
         name: 'ParserMob'
         owner: "SubMob"
         dependencyIssueId: "27"
+        iosProjectPath: '^$' # no iOS project — never matches
   - source: relative/docs/
     dest: docs/
     template:

--- a/relative/renovate.json
+++ b/relative/renovate.json
@@ -19,11 +19,10 @@
     "enabled": true,
     "commitMessageAction": "[{{ repository.owner }}/{{ repository.name }}#{{ repository.dependencyIssueId }}] Lock file maintenance"
   },
-  "customManagers": [
+  "regexManagers": [
     {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "/^ios/CCC\\.xcodeproj/project\\.pbxproj$/"
+      "fileMatch": [
+        "{{ repository.iosProjectPath }}"
       ],
       "matchStrings": [
         "repositoryURL = \"https://github.com/(?<owner>[^/]+)/(?<repo>[^\"/]+?)(?:\\.git)?\";\\s*requirement = \\{\\s*kind = exactVersion;\\s*version = (?<currentValue>[^;]+);"


### PR DESCRIPTION
Two fixes to the shared Renovate iOS SPM (Swift Package Manager) regex manager in `relative/renovate.json` + `.github/sync.yml`.

### 1. Configurable iOS project path
The `fileMatch` hard-coded CCC's `ios/CCC.xcodeproj/project.pbxproj`, so it was dead in every other repo. Templatized as `{{ repository.iosProjectPath }}`, set per repo:
- CCC → `ios/CCC.xcodeproj/project.pbxproj`
- TraceFit → `ios/TraceFit.xcodeproj/project.pbxproj`
- AdTrack → `iosApp/iosApp.xcodeproj/project.pbxproj`
- Global + SubMob libs (no iOS) → `^$` (never matches)

### 2. Fix dependency name in PR titles
Renovate PRs were titled *"Update dependency Oztechan/CCC to v2"* (e.g. [Oztechan/CCC#4792](https://github.com/Oztechan/CCC/pull/4792)) — bumping CCC to its **own** release tag — instead of naming the real SPM package like before ([#4620](https://github.com/Oztechan/CCC/pull/4620)).

Cause: `depNameTemplate: "{{owner}}/{{repo}}"` was being substituted by the file-sync action's templating to the **target repo** (`Oztechan/CCC`), clobbering Renovate's regex capture groups. CCC's live `renovate.json` literally reads `"depNameTemplate": "Oztechan/CCC"`.

Fix: capture the package as a single `(?<depName>…)` group and drop `depNameTemplate`, so the manager has no `{{ }}` tokens for the sync to clobber. Titles become *"Update dependency matteopuc/swiftui-navigation-stack to vX"* again.

Resolves Oztechan/Global#211