### PR TITLE
[Oztechan/Global#214] Fix Renovate iOS SPM dependency name

### DIFF
--- a/relative/renovate.json
+++ b/relative/renovate.json
@@ -25,10 +25,9 @@
         "{{ repository.iosProjectPath }}"
       ],
       "matchStrings": [
-        "repositoryURL = \"https://github.com/(?<owner>[^/]+)/(?<repo>[^\"/]+?)(?:\\.git)?\";\\s*requirement = \\{\\s*kind = exactVersion;\\s*version = (?<currentValue>[^;]+);"
+        "repositoryURL = \"https://github.com/(?<depName>[^/]+/[^\"/]+?)(?:\\.git)?\";\\s*requirement = \\{\\s*kind = exactVersion;\\s*version = (?<currentValue>[^;]+);"
       ],
-      "datasourceTemplate": "github-tags",
-      "depNameTemplate": "{{repository.owner}}/{{repository.name}}"
+      "datasourceTemplate": "github-tags"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
iOS Swift Package Renovate PRs were titled *"Update dependency Oztechan/CCC to v2"* — bumping the repo to its own release tag — instead of naming the real package like before ([Oztechan/CCC#4620](https://github.com/Oztechan/CCC/pull/4620)).

**Cause:** `depNameTemplate` used `{{repository.owner}}/{{repository.name}}` (previously `{{owner}}/{{repo}}`). Both get resolved by the config file-sync action's templating to the **target repo**, clobbering Renovate's intended regex capture groups — CCC's live `renovate.json` literally reads `"depNameTemplate": "Oztechan/CCC"`.

**Fix:** capture the package directly as `(?<depName>[^/]+/[^"/]+?)` in `matchStrings` and remove `depNameTemplate`. The manager now has no sync-substituted tokens (except the intended `iosProjectPath`), so titles return to *"Update dependency <owner>/<repo> to vX"*.

Resolves Oztechan/Global#214