### PR TITLE
[Oztechan/Global#216] Tune detekt for Compose (previews + UI magic numbers)

### DIFF
--- a/detekt.yml
+++ b/detekt.yml
@@ -11,6 +11,14 @@ style:
   WildcardImport:
     active: true
     excludeImports: [ ] # default config excludes java.util.*
+  # Compose UI idioms: numeric literals in composables/previews (dp, weights, colors, sample
+  # data) and in property declarations (theme palettes) are expected, not code smells.
+  MagicNumber:
+    ignorePropertyDeclaration: true
+    ignoreAnnotated: [ 'Composable', 'Preview' ]
+  # @Preview composables are invoked by the IDE preview renderer, not by code.
+  UnusedPrivateMember:
+    ignoreAnnotated: [ 'Preview' ]
 
 complexity:
   NamedArguments:


### PR DESCRIPTION
The shared `detekt.yml` (`warningsAsErrors: true`) flags idiomatic Compose patterns as errors, blocking Compose-first apps like AdTrack (108 findings, almost all Compose noise).

Adds annotation-scoped relaxations:
- `MagicNumber`: `ignorePropertyDeclaration: true` + `ignoreAnnotated: [Composable, Preview]` — theme palettes, dp/weights, preview sample data.
- `UnusedPrivateMember`: `ignoreAnnotated: [Preview]` — `@Preview` composables are used by the IDE renderer.

Genuine magic numbers in business logic and real complexity smells are **still** enforced (AdTrack fixes those in source separately). Verified locally: with this config + AdTrack's source fixes, `detektAll` passes clean (108 → 0).

Resolves Oztechan/Global#216