### PR TITLE
[Oztechan/Global#220] Point Project Automations at Oztechan Apps (#13) with milestone workflow

### DIFF
--- a/.github/workflows/project.yml
+++ b/.github/workflows/project.yml
@@ -16,5 +16,5 @@ jobs:
   ProjectAutomations:
     uses: Oztechan/Global/.github/workflows/reusable-project.yml@develop
     with:
-      project_id: 8
+      project_id: 13
     secrets: inherit


### PR DESCRIPTION
Points this repo's Project Automations at the consolidated **Oztechan Apps** project (#13) and adopts the milestone-based reusable workflow (Oztechan/Global#219).

- `project_id: 13`
- Uses reusable-project.yml@develop, which already carries the milestone workflow (no SHA bump needed)
- Drops the removed `NEXT_VERSION` secret usage

Resolves Oztechan/Global#220