### PR TITLE
[Oztechan/Global#222] Migrate mirrored Renovate config to customManagers schema

### DIFF
--- a/relative/renovate.json
+++ b/relative/renovate.json
@@ -19,10 +19,11 @@
     "enabled": true,
     "commitMessageAction": "[{{ repository.owner }}/{{ repository.name }}#{{ repository.dependencyIssueId }}] Lock file maintenance"
   },
-  "regexManagers": [
+  "customManagers": [
     {
-      "fileMatch": [
-        "{{ repository.iosProjectPath }}"
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/{{ repository.iosProjectPath }}/"
       ],
       "matchStrings": [
         "repositoryURL = \"https://github.com/(?<depName>[^/]+/[^\"/]+?)(?:\\.git)?\";\\s*requirement = \\{\\s*kind = exactVersion;\\s*version = (?<currentValue>[^;]+);"


### PR DESCRIPTION
Renovate deprecated `regexManagers`/`fileMatch` and opens config-migration PRs in each app repo (e.g. Oztechan/CCC#4807). Since `renovate.json` is mirrored from here to all Oztechan/SubMob repos via `.github/sync.yml`, the migration belongs in the source template.

- `regexManagers` → `customManagers` with `customType: "regex"`
- `fileMatch` → `managerFilePatterns`, with `{{ repository.iosProjectPath }}` wrapped in `/` delimiters so the substituted value is interpreted as a regex — for CCC this renders byte-identical to what Renovate's own migration PR produced; the `^$` placeholder for repos without an iOS project stays a valid never-matching regex
- No `.github/sync.yml` changes needed; `matchStrings` (incl. the #215 depName fix) untouched

Once merged and synced, Renovate will close its per-repo migration PRs automatically.

Resolves Oztechan/Global#222