### PR TITLE
[Oztechan/Global#224] Actually apply project-automation behavior change (missed in #225)

### DIFF
--- a/.github/workflows/reusable-project.yml
+++ b/.github/workflows/reusable-project.yml
@@ -6,6 +6,10 @@ on:
       project_id:
         required: true
         type: string
+      organization:
+        required: false
+        default: Oztechan
+        type: string
     secrets:
       PERSONAL_ACCESS_TOKEN:
         required: false
@@ -40,7 +44,7 @@ jobs:
         uses: leonsteinhaeuser/project-beta-automations@v2.2.1
         with:
           gh_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-          organization: Oztechan
+          organization: ${{ inputs.organization }}
           project_id: ${{ inputs.project_id }}
           resource_node_id: ${{ github.event.issue.node_id }}
           status_value: "📖 To do"
@@ -57,18 +61,41 @@ jobs:
         run: |
           gh issue edit "${{ github.event.issue.number }}" --repo "${{ github.repository }}" --milestone "${{ steps.milestone.outputs.title }}"
 
-      - name: 'Move Related Issue to "🏗 PR Review"'
+      # When a PR is opened for an issue, the issue should reflect that work is still actively
+      # happening — it stays in "🚧 In Progress" (moved there if it wasn't already) rather than
+      # flipping to "🏗 PR Review". This first step moves the PR *and* its linked issue to
+      # In Progress (move_related_issues: true); the next step then moves only the PR on to
+      # PR Review, leaving the issue in In Progress.
+      - name: 'Move Related Issue to "🚧 In Progress"'
         if: |
           github.event_name == 'pull_request' &&
           (github.event.action == 'opened' || github.event.action == 'ready_for_review' || github.event.action == 'reopened')
         uses: leonsteinhaeuser/project-beta-automations@v2.2.1
         with:
           gh_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-          organization: Oztechan
+          organization: ${{ inputs.organization }}
+          project_id: ${{ inputs.project_id }}
+          resource_node_id: ${{ github.event.pull_request.node_id }}
+          status_value: "🚧 In Progress"
+          move_related_issues: true
+
+      # Move only the PR card to PR Review. The action stores move_related_issues in $GITHUB_ENV,
+      # which leaks across steps within a job — so we ALSO pin MOVE_RELATED_ISSUES=false here to
+      # guarantee this step never drags the linked issue (left In Progress above) into PR Review.
+      - name: 'Move PR to "🏗 PR Review"'
+        if: |
+          github.event_name == 'pull_request' &&
+          (github.event.action == 'opened' || github.event.action == 'ready_for_review' || github.event.action == 'reopened')
+        env:
+          MOVE_RELATED_ISSUES: "false"
+        uses: leonsteinhaeuser/project-beta-automations@v2.2.1
+        with:
+          gh_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          organization: ${{ inputs.organization }}
           project_id: ${{ inputs.project_id }}
           resource_node_id: ${{ github.event.pull_request.node_id }}
           status_value: "🏗 PR Review"
-          move_related_issues: true
+          move_related_issues: false
 
       # Same nearest-milestone default for PRs; you can manually move a PR to a later milestone if it
       # won't make the current one. Never overrides a milestone already set.
@@ -83,27 +110,16 @@ jobs:
         run: |
           gh pr edit "${{ github.event.pull_request.number }}" --repo "${{ github.repository }}" --milestone "${{ steps.milestone.outputs.title }}"
 
-      - name: 'Add dependency or config PR to "🏗 PR Review"'
-        if: |
-          github.event_name == 'pull_request' &&
-          (github.event.pull_request.user.login == 'renovate[bot]' || github.head_ref == 'repo-sync/Global/default') &&
-          (github.event.action == 'opened' || github.event.action == 'ready_for_review' || github.event.action == 'reopened')
-        uses: leonsteinhaeuser/project-beta-automations@v2.2.1
-        with:
-          gh_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-          organization: Oztechan
-          project_id: ${{ inputs.project_id }}
-          resource_node_id: ${{ github.event.pull_request.node_id }}
-          status_value: "🏗 PR Review"
-
-      - name: 'Move Related Issue to "🚧 In Progress"'
+      # A PR sent back to draft means work resumed — pull the PR and its linked issue back to
+      # In Progress.
+      - name: 'Move PR and Related Issue back to "🚧 In Progress"'
         if: |
           github.event_name == 'pull_request' &&
           github.event.action == 'converted_to_draft'
         uses: leonsteinhaeuser/project-beta-automations@v2.2.1
         with:
           gh_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-          organization: Oztechan
+          organization: ${{ inputs.organization }}
           project_id: ${{ inputs.project_id }}
           resource_node_id: ${{ github.event.pull_request.node_id }}
           status_value: "🚧 In Progress"
@@ -117,7 +133,7 @@ jobs:
         uses: leonsteinhaeuser/project-beta-automations@v2.2.1
         with:
           gh_token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
-          organization: Oztechan
+          organization: ${{ inputs.organization }}
           project_id: ${{ inputs.project_id }}
           resource_node_id: ${{ github.event.pull_request.node_id }}
           status_value: "✅ Done"


### PR DESCRIPTION
Reopens the work for #224.

#225 merged but only carried the deletion of `reusable-project-submodules.yml` — the edits to `reusable-project.yml` were never staged, so the behavior change never shipped (AdTrack still moved the issue to PR Review).

This PR applies the actual change:
- `organization` input (defaults to `Oztechan`).
- On PR open: linked issue -> `🚧 In Progress`; only the PR -> `🏗 PR Review`.
- Guards the PR-Review step with `env: MOVE_RELATED_ISSUES: "false"` because the action persists that flag via `$GITHUB_ENV` across steps, which would otherwise leak `true` from the In-Progress step and drag the issue into PR Review.
- Removes the now-redundant dependency/config PR step (the PR-Review step already covers every opened PR).