### PR TITLE
[Oztechan/Global#230] Add reusable disable-kotlin-incremental-native action

### DIFF
--- a/actions/disable-kotlin-incremental-native/action.yml
+++ b/actions/disable-kotlin-incremental-native/action.yml
@@ -1,0 +1,13 @@
+name: 'Disable Kotlin Incremental Native'
+description: 'Disables Kotlin/Native incremental compilation for CI by setting kotlin.incremental.native=false in the global Gradle properties (~/.gradle/gradle.properties).'
+runs:
+  using: 'composite'
+  steps:
+    - name: Disable Kotlin incremental native for CI
+      shell: bash
+      run: |
+        mkdir -p ~/.gradle
+        touch ~/.gradle/gradle.properties
+        # `-i.bak` works on both GNU and BSD/macOS sed, unlike bare `-i` (GNU) or `-i ''` (BSD)
+        sed -i.bak '/kotlin.incremental.native/d' ~/.gradle/gradle.properties && rm -f ~/.gradle/gradle.properties.bak
+        echo "kotlin.incremental.native=false" >> ~/.gradle/gradle.properties


### PR DESCRIPTION
## What

Adds a composite action `actions/disable-kotlin-incremental-native` that sets `kotlin.incremental.native=false` in `~/.gradle/gradle.properties`.

## Why

This "Disable Kotlin incremental native for CI" step was duplicated across CCC (`main.yml`, `build.yml`) and AdTrack (`main.yml`, `release.yml`). Centralizing it here lets both repos consume it via `Oztechan/Global/actions/disable-kotlin-incremental-native`.

## Notes

- `sed` uses the portable `-i.bak` form so the action also works on Linux runners (the original inline `sed -i ''` was BSD/macOS-only).

Closes #230

Consumers:
- Oztechan/CCC#4821
- Oztechan/AdTrack#116